### PR TITLE
fix: Database access and DataStorage rules

### DIFF
--- a/lib/core/interfaces/db_interface.dart
+++ b/lib/core/interfaces/db_interface.dart
@@ -2,10 +2,9 @@ abstract interface class DbInterface<T> {
   Future<void> insert({
     required String id,
     required T data,
-    required String createdBy,
   });
 
-  Future<List<T>?> getAllData(String createdBy);
+  Future<List<T>?> getAllData();
 
   Future<T?> getData(String id);
 
@@ -14,7 +13,6 @@ abstract interface class DbInterface<T> {
   Future<void> update({
     required String id,
     required T data,
-    required String createdBy,
   });
 
   Future<void> close();

--- a/lib/core/services/firestore_db.dart
+++ b/lib/core/services/firestore_db.dart
@@ -1,32 +1,38 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:simon_ai/core/interfaces/db_interface.dart';
 
 interface class FirestoreRankingDb
     implements DbInterface<Map<String, dynamic>> {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final FirebaseAuth _auth = FirebaseAuth.instance;
 
   final String collection;
   final String subCollection;
+  final defaultId = 'default';
 
   FirestoreRankingDb({
     required this.collection,
     required this.subCollection,
   });
 
+  CollectionReference<Map<String, dynamic>> _getCollectionReference() {
+    final user = _auth.currentUser;
+    return _firestore
+        .collection(collection)
+        .doc(user?.uid ?? defaultId)
+        .collection(subCollection);
+  }
+
   @override
   Future<void> close() async => _firestore.terminate();
 
   @override
-  Future<void> delete(String id) =>
-      _firestore.collection(collection).doc(id).delete();
+  Future<void> delete(String id) => _getCollectionReference().doc(id).delete();
 
   @override
-  Future<List<Map<String, dynamic>>> getAllData(String createdBy) async {
-    final snapshot = await _firestore
-        .collection(collection)
-        .doc(createdBy)
-        .collection(subCollection)
-        .get();
+  Future<List<Map<String, dynamic>>> getAllData() async {
+    final snapshot = await _getCollectionReference().get();
     return snapshot.docs.map((doc) => doc.data()).toList();
   }
 
@@ -34,31 +40,19 @@ interface class FirestoreRankingDb
   Future<void> insert({
     required String id,
     required Map<String, dynamic> data,
-    required String createdBy,
   }) =>
-      _firestore
-          .collection(collection)
-          .doc(createdBy)
-          .collection(subCollection)
-          .doc(id)
-          .set(data);
+      _getCollectionReference().doc(id).set(data);
 
   @override
   Future<void> update({
     required String id,
     required Map<String, dynamic> data,
-    required String createdBy,
   }) =>
-      _firestore
-          .collection(collection)
-          .doc(createdBy)
-          .collection(subCollection)
-          .doc(id)
-          .update(data);
+      _getCollectionReference().doc(id).update(data);
 
   @override
-  Future<Map<String, dynamic>?> getData(String id) async {
-    final snapshot = await _firestore.collection(collection).doc(id).get();
+  Future<Map<String, dynamic>?> getData(String userId) async {
+    final snapshot = await _getCollectionReference().doc(userId).get();
     if (snapshot.exists) {
       return snapshot.data();
     }

--- a/lib/core/source/user_remote_source.dart
+++ b/lib/core/source/user_remote_source.dart
@@ -7,11 +7,10 @@ class UserRemoteSource {
 
   UserRemoteSource();
 
-  Future<void> createUser(String id, Player data, String createdBy) async {
+  Future<void> createUser(String id, Player data) async {
     await _firestoreDb.insert(
       id: id,
       data: data.toJson(),
-      createdBy: createdBy,
     );
   }
 
@@ -19,19 +18,18 @@ class UserRemoteSource {
       .getData(id)
       .then((value) => value == null ? null : Player.fromJson(value));
 
-  Future<void> updateUser(String id, Player data, String createdBy) =>
+  Future<void> updateUser(String id, Player data) =>
       _firestoreDb.update(
         id: id,
         data: data.toJson(),
-        createdBy: createdBy,
       );
 
   Future<void> deleteUser(String id) async {
     await _firestoreDb.delete(id);
   }
 
-  Future<List<Player>> getAllUsers(String createdBy) async =>
-      (await _firestoreDb.getAllData(createdBy))
+  Future<List<Player>> getAllUsers() async =>
+      (await _firestoreDb.getAllData())
           .map((e) => Player.fromJson(e))
           .toList();
 

--- a/lib/core/source/user_remote_source.dart
+++ b/lib/core/source/user_remote_source.dart
@@ -18,8 +18,7 @@ class UserRemoteSource {
       .getData(id)
       .then((value) => value == null ? null : Player.fromJson(value));
 
-  Future<void> updateUser(String id, Player data) =>
-      _firestoreDb.update(
+  Future<void> updateUser(String id, Player data) => _firestoreDb.update(
         id: id,
         data: data.toJson(),
       );
@@ -29,9 +28,7 @@ class UserRemoteSource {
   }
 
   Future<List<Player>> getAllUsers() async =>
-      (await _firestoreDb.getAllData())
-          .map((e) => Player.fromJson(e))
-          .toList();
+      (await _firestoreDb.getAllData()).map((e) => Player.fromJson(e)).toList();
 
   Future<void> close() => _firestoreDb.close();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -89,7 +89,6 @@ flutter:
   generate: true
   uses-material-design: true
   assets:
-    - assets/images/
     - assets/models/
     - assets/audio/
     - environments/


### PR DESCRIPTION


#### :pencil2: Description:

The access were wong, I moved the logic to the direstore_db

The new rules are:

```
rules_version = '2';

service cloud.firestore {
  match /databases/{database}/documents {
    match /ranking/{user} {
    	function isRegisteredUserAuthorized(createdBy) {
    		return (request.auth != null && request.auth.uid == createdBy);
    	}
      allow update, read: if isRegisteredUserAuthorized(resource.data.created_by);
      allow create: if isRegisteredUserAuthorized(request.resource.data.created_by);
  	}
    match /ranking/default/* {
      function isUnregisteredUserAuthorized(createdBy) {
    		return (request.auth == null && createdBy == "")
    	}
      allow update, read: if isUnregisteredUserAuthorized(resource.data.created_by);
      allow create: if isUnregisteredUserAuthorized(request.resource.data.created_by);
    }
	}
}
```
